### PR TITLE
Fix link to Contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Lessons can now be viewed on [ElixirSchool.com](https://elixirschool.com).
 
-_Feedback and participation is welcome. Please see [Contributing](CONTRIBUTIING.md) for more details on how to get involved._
+_Feedback and participation is welcome. Please see [Contributing](CONTRIBUTING.md) for more details on how to get involved._
 
 ### Running
 


### PR DESCRIPTION
Previous commit [e2de72d33bad2b60240b8b0dcaaf28c2287008e](https://github.com/doomspork/elixir-school/commit/de2de72d33bad2b60240b8b0dcaaf28c2287008e) fixed CONTRIBUTING.md filename but left README.md link broken.
